### PR TITLE
fix: responsive styles header, lesson intersections

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -41,7 +41,7 @@ export const Header = () => {
           {currentWeekEvenOrOdd} week (no. {currentWeekSemesterNo})
         </Badge>
       </section>
-      <section className="d-flex flex-row align-items-center gap-2">
+      <section className="d-flex flex-row flex-wrap align-items-center gap-2">
         <VictimBadge />
         <VictimDropdown />
         <ThemeDropdown />

--- a/client/src/components/LessonIntersection.tsx
+++ b/client/src/components/LessonIntersection.tsx
@@ -23,7 +23,7 @@ export const LessonIntersection = ({ index, intersection }: Props) => {
       onClick={() => setVictimId(intersection.id)}
       title={`Show ${intersection.name}'s timetable.`}
     >
-      <h6 className="m-0">
+      <h6 className="m-0 text-truncate">
         {intersection.name} <HiOutlineExternalLink />
       </h6>
     </div>


### PR DESCRIPTION
- fix (`...`) pro dlouhe jmena v lesson intersections:
![Screenshot_2024-09-26-12-37-36_7040x1806](https://github.com/user-attachments/assets/4ee9d7c1-960b-403b-a304-59e748801f92)

- fix pro dlouhe jmena ve victim selectu

   pred:
![image](https://github.com/user-attachments/assets/3fae211d-83a4-423e-9783-4a48cfe0f9ba)
   po:
![image](https://github.com/user-attachments/assets/8554b6bd-a373-4de1-8e63-437142605c1e)

