### PR TITLE
fix: collision detection

### DIFF
--- a/client/src/components/Lessons.tsx
+++ b/client/src/components/Lessons.tsx
@@ -1,12 +1,12 @@
 import '../styles/Lessons.scss';
 
-import { areIntervalsOverlapping, getDay } from 'date-fns';
+import { getDay } from 'date-fns';
 import { useMemo } from 'react';
 
 import useVictim from '../hooks/useVictim';
 import { LessonInfo, PersonInfo } from '../services/DataService';
-import { intervalFromLesson } from '../utils/TimeUtil';
-import { CollisionInfo, Lesson } from './Lesson';
+import { calculateLessonCollisions } from '../utils/collisions';
+import { Lesson } from './Lesson';
 import { TimeIndicator } from './TimeIndicator';
 
 export type ContextualizedLesson = LessonInfo & {
@@ -28,32 +28,10 @@ const getDayName = (index: number) => {
 export const Lessons = ({ lessons, dayIndex }: Props) => {
   const { activeVictim } = useVictim();
 
-  const lessonsWithCollisions = useMemo(() => {
-    const returnArr: (ContextualizedLesson & CollisionInfo)[] = [];
-
-    lessons.forEach((lesson) => {
-      let currentLevel = 1;
-
-      returnArr.forEach((sortedLesson) => {
-        if (
-          areIntervalsOverlapping(
-            intervalFromLesson(lesson),
-            intervalFromLesson(sortedLesson),
-          )
-        ) {
-          currentLevel = sortedLesson.levelCount += 1;
-        }
-      });
-
-      returnArr.push({
-        ...lesson,
-        level: currentLevel,
-        levelCount: currentLevel,
-      });
-    });
-
-    return returnArr;
-  }, [lessons, activeVictim]);
+  const lessonsWithCollisions = useMemo(
+    () => calculateLessonCollisions(lessons),
+    [lessons, activeVictim],
+  );
 
   return (
     <>

--- a/client/src/utils/collisions.ts
+++ b/client/src/utils/collisions.ts
@@ -4,7 +4,7 @@ import { intervalFromLesson } from './TimeUtil';
 type CompareKeyFunction<T> = (x: T) => number;
 type CompareFunction<T> = (a: T, b: T) => number;
 const chainComparisons =
-  <T>(funcs: CompareFunction<T>[]): CompareFunction<T> =>
+  <T>(...funcs: CompareFunction<T>[]): CompareFunction<T> =>
   (a, b) => {
     for (const f of funcs) {
       const res = f(a, b);
@@ -45,7 +45,7 @@ const toSortedTimes = (
       { time: interval.end, lessonIdx, type: LessonCollisionTimeType.END },
     ])
     .toSorted(
-      chainComparisons([
+      chainComparisons(
         keyCompare(({ time }) => time.getTime()),
         keyCompare(({ type }) =>
           // Order start times after end times. This makes lessons which just meet at their end
@@ -56,7 +56,7 @@ const toSortedTimes = (
         ),
         (a, b) =>
           compareLessonNames(lessons[a.lessonIdx], lessons[b.lessonIdx]),
-      ]),
+      ),
     );
 
 export type ContextualizedCollidedLesson = ContextualizedLesson & {
@@ -93,9 +93,7 @@ export const calculateLessonCollisions = (
   const times = toSortedTimes(lessons);
   for (const time of times) {
     if (time.type === LessonCollisionTimeType.START) {
-      const level = availableLevels.length
-        ? availableLevels.splice(0, 1)[0]
-        : nextLevel++;
+      const level = availableLevels.shift() ?? nextLevel++;
 
       levels[time.lessonIdx] = level;
       currBlock.push(time.lessonIdx);

--- a/client/src/utils/collisions.ts
+++ b/client/src/utils/collisions.ts
@@ -1,0 +1,120 @@
+import { ContextualizedLesson } from '../components/Lessons';
+import { intervalFromLesson } from './TimeUtil';
+
+type CompareKeyFunction<T> = (x: T) => number;
+type CompareFunction<T> = (a: T, b: T) => number;
+const chainComparisons =
+  <T>(funcs: CompareFunction<T>[]): CompareFunction<T> =>
+  (a, b) => {
+    for (const f of funcs) {
+      const res = f(a, b);
+      if (res !== 0) return res;
+    }
+
+    return 0;
+  };
+
+const keyCompare =
+  <T>(key: CompareKeyFunction<T>): CompareFunction<T> =>
+  (a, b) =>
+    key(a) - key(b);
+
+const compareLessonNames = (
+  a: ContextualizedLesson,
+  b: ContextualizedLesson,
+): number => a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+
+enum LessonCollisionTimeType {
+  START = 0,
+  END = 1,
+}
+
+type LessonCollisionTime = {
+  time: Date;
+  lessonIdx: number;
+  type: LessonCollisionTimeType;
+};
+
+const toSortedTimes = (
+  lessons: ContextualizedLesson[],
+): LessonCollisionTime[] =>
+  lessons
+    .map(intervalFromLesson)
+    .flatMap((interval, lessonIdx) => [
+      { time: interval.start, lessonIdx, type: LessonCollisionTimeType.START },
+      { time: interval.end, lessonIdx, type: LessonCollisionTimeType.END },
+    ])
+    .toSorted(
+      chainComparisons([
+        keyCompare(({ time }) => time.getTime()),
+        keyCompare(({ type }) =>
+          // Order start times after end times. This makes lessons which just meet at their end
+          // times still count as not colliding and allows them to break collision blocks.
+          // It's up to discussion and testing whether we want this or not, but in the end it
+          // shouldn't matter too much as most of our blocks still have 15 minute gaps inbetween
+          type === LessonCollisionTimeType.START ? 1 : 0,
+        ),
+        (a, b) =>
+          compareLessonNames(lessons[a.lessonIdx], lessons[b.lessonIdx]),
+      ]),
+    );
+
+export type ContextualizedCollidedLesson = ContextualizedLesson & {
+  level: number;
+  levelCount: number;
+};
+
+/**
+ * Calculate the collisions between lessons in a day.
+ *
+ * Essentially this whole task boils down to an [interval graph](https://en.wikipedia.org/wiki/Interval_graph)
+ * colouring problem. We create an array of start and end times of all lessons, sort it in ascending
+ * order. We iterate these times in order, greedily assigning each lesson the first from a queue of
+ * levels. If we run out of levels, we add a new one. Importantly, we return each lesson's level
+ * back to the queue on its end time.
+ *
+ * The algorithm here has a modification which waits for points where there are no running intervals
+ * and resets the queue and level counts at these points. This allows lessons to only shrink when
+ * they actually belong to a conflicting block.
+ *
+ * @param lessons the set of lessons to calculate collisions among
+ * @returns [lessons] with collision information
+ */
+export const calculateLessonCollisions = (
+  lessons: ContextualizedLesson[],
+): ContextualizedCollidedLesson[] => {
+  const levels: Record<number, number> = {};
+  const levelCounts: Record<number, number> = {};
+
+  let currBlock: number[] = [];
+  let nextLevel = 1;
+  let availableLevels: number[] = [];
+
+  const times = toSortedTimes(lessons);
+  for (const time of times) {
+    if (time.type === LessonCollisionTimeType.START) {
+      const level = availableLevels.length
+        ? availableLevels.splice(0, 1)[0]
+        : nextLevel++;
+
+      levels[time.lessonIdx] = level;
+      currBlock.push(time.lessonIdx);
+    } else {
+      availableLevels.push(levels[time.lessonIdx]);
+      if (availableLevels.length === nextLevel - 1) {
+        // No intervals open, ie we have reached a time with no overlapping lessons. We can reset
+        // level counts here so the next blocks can again be as large as they need
+        for (const lesson of currBlock) levelCounts[lesson] = nextLevel - 1;
+        currBlock = [];
+        availableLevels = [];
+        nextLevel = 1;
+      }
+    }
+  }
+
+  return lessons.map((lesson, lessonIdx) => ({
+    ...lesson,
+    level: levels[lessonIdx],
+    levelCount: levelCounts[lessonIdx],
+  }));
+};


### PR DESCRIPTION
In some cases lesson collisions were rendered weird:
<img width="501" alt="image" src="https://github.com/user-attachments/assets/fee1c708-7899-492e-b73d-3128b7231b12">

Essentially, the current algorithm didn't take partially overlapping classes like this into account, and just sweeping the day and counting intersecting classes led to this result. 

The new algorithm is a slightly modified interval graph colouring, and can handle these cases properly. The modification consists of resetting the queue of available colours whenever a colliding block ends, which prevents all lessons of the day being squashed because of a single collision.
<img width="503" alt="image" src="https://github.com/user-attachments/assets/d0740b07-748f-4152-a376-69ba53accbd5">
