### PR TITLE
Improve victim search

### DIFF
--- a/client/src/components/VictimDropdown.tsx
+++ b/client/src/components/VictimDropdown.tsx
@@ -2,6 +2,25 @@ import { MutableRefObject, useEffect, useMemo, useRef, useState } from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 
 import useVictim from '../hooks/useVictim';
+import { PersonData } from '../services/DataService';
+
+/**
+ * Normalize a string for search.
+ * The main goal of this was to make diacritics irrelevant to search. The function also lowercases
+ * the string, removes all non-alphanumeric characters and collapses whitespace into single spaces.
+ * All of this should hopefully make search natural without doing any fancy fuzzy search.
+ */
+const normalizeForSearch = (name: String): string =>
+  name
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .trim()
+    .replace(/\s+/g, ' ');
+
+type SearchableVictim = PersonData & {
+  normalizedName: string;
+};
 
 export function VictimDropdown() {
   const { setVictimId, people } = useVictim();
@@ -25,14 +44,25 @@ export function VictimDropdown() {
     }
   }, [displayVictimDropdown]);
 
-  const victimSearchLowerCase = victimSearch.toLowerCase();
+  const victimSearchLowerCase = normalizeForSearch(victimSearch);
+
+  const searchableVictims = useMemo(
+    () =>
+      people.map(
+        (victim): SearchableVictim => ({
+          ...victim,
+          normalizedName: normalizeForSearch(victim.name),
+        }),
+      ),
+    [people],
+  );
 
   const filteredVictims = useMemo(
     () =>
-      people.filter((victim) =>
-        victim.name.toLowerCase().startsWith(victimSearchLowerCase),
+      searchableVictims.filter((victim) =>
+        victim.normalizedName.startsWith(victimSearchLowerCase),
       ),
-    [victimSearch, people],
+    [victimSearch, searchableVictims],
   );
 
   // TODO: refactor

--- a/client/src/components/VictimDropdown.tsx
+++ b/client/src/components/VictimDropdown.tsx
@@ -60,7 +60,7 @@ export function VictimDropdown() {
   const filteredVictims = useMemo(
     () =>
       searchableVictims.filter((victim) =>
-        victim.normalizedName.startsWith(victimSearchLowerCase),
+        victim.normalizedName.includes(victimSearchLowerCase),
       ),
     [victimSearch, searchableVictims],
   );


### PR DESCRIPTION
This PR does two things. I'm happy with the first one, the second one I'm open to more discussion about:
- Introduces search string normalisation. It builds on [Unicode decomposition](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize), making diacritics irrelevant to search. It also disregards non-alphanumeric characters and normalises all whitespace to a single space character, hopefully making search much more intuitive and simpler to use.
- Changes the `startsWith` to an `includes` comparison. This allows searching more terms (for example, STPN now pops up when you search the word `swag` :D ). The slight downside is that this increases the number of matches victims for some search strings, but I've tested it on some mock data from a few semesters back and it didn't seem like too big of an issue.